### PR TITLE
#31 - Refactor

### DIFF
--- a/lib/src/features/auth/presentation/pages/login_page.dart
+++ b/lib/src/features/auth/presentation/pages/login_page.dart
@@ -29,6 +29,7 @@ class LoginPage extends StatelessWidget {
                     AppConstants.appName,
                     style: Theme.of(context).textTheme.headlineLarge?.copyWith(
                       fontWeight: FontWeight.bold,
+                      color: Colors.white,
                     ),
                     textAlign: TextAlign.center,
                   ),
@@ -37,6 +38,7 @@ class LoginPage extends StatelessWidget {
                     localizations.loginTitle,
                     style: Theme.of(context).textTheme.headlineMedium?.copyWith(
                       fontWeight: FontWeight.bold,
+                      color: Colors.white,
                     ),
                     textAlign: TextAlign.center,
                   ),

--- a/lib/src/features/auth/presentation/pages/register_page.dart
+++ b/lib/src/features/auth/presentation/pages/register_page.dart
@@ -37,6 +37,7 @@ class _RegisterPageState extends State<RegisterPage> {
                     AppConstants.appName,
                     style: Theme.of(context).textTheme.headlineLarge?.copyWith(
                       fontWeight: FontWeight.bold,
+                      color: Colors.white,
                     ),
                     textAlign: TextAlign.center,
                   ),
@@ -45,6 +46,7 @@ class _RegisterPageState extends State<RegisterPage> {
                     localizations.registerTitle,
                     style: Theme.of(context).textTheme.headlineMedium?.copyWith(
                       fontWeight: FontWeight.bold,
+                      color: Colors.white,
                     ),
                     textAlign: TextAlign.center,
                   ),

--- a/lib/src/features/auth/presentation/widgets/forgot_password_form.dart
+++ b/lib/src/features/auth/presentation/widgets/forgot_password_form.dart
@@ -33,16 +33,20 @@ class _ForgotPasswordFormState extends State<ForgotPasswordForm> {
         children: [
           Text(
             localizations.forgotPasswordEmailInstruction,
-            style: Theme.of(context).textTheme.bodyLarge,
+            style: Theme.of(
+              context,
+            ).textTheme.bodyLarge?.copyWith(color: Colors.white),
             textAlign: TextAlign.center,
           ),
           const SizedBox(height: 24),
           TextFormField(
             controller: emailController,
             keyboardType: TextInputType.emailAddress,
+            style: const TextStyle(color: Colors.white),
             decoration: InputDecoration(
               labelText: localizations.emailLabel,
-              prefixIcon: Icon(Icons.email_outlined),
+              labelStyle: TextStyle(color: Colors.white70),
+              prefixIcon: Icon(Icons.email_outlined, color: Colors.white),
             ),
             validator: (value) {
               if (value == null || value.isEmpty) {


### PR DESCRIPTION
The text color in the forgot password form instruction, email input field, login page title, and register page title has been changed to white. The email icon color in the forgot password form has also been changed to white.